### PR TITLE
Fix keystore format

### DIFF
--- a/Neuron/Sections/Wallet/WalletDetails/WalletDetailController.swift
+++ b/Neuron/Sections/Wallet/WalletDetails/WalletDetailController.swift
@@ -33,7 +33,7 @@ class WalletDetailController: UITableViewController {
         walletIconImageView.image = UIImage(data: walletModel.iconData)
     }
 
-    func creatDeleteWalletPageItem() -> PasswordPageItem {
+    func createDeleteWalletPageItem() -> PasswordPageItem {
         let passwordPageItem = PasswordPageItem.create(title: "删除钱包", actionButtonTitle: "确认删除")
 
         passwordPageItem.actionHandler = { [weak self] item in
@@ -71,7 +71,7 @@ class WalletDetailController: UITableViewController {
     }
 
     @IBAction func didDeleteWallet(_ sender: UIButton) {
-        deleteBulletinManager = BLTNItemManager(rootItem: creatDeleteWalletPageItem())
+        deleteBulletinManager = BLTNItemManager(rootItem: createDeleteWalletPageItem())
         deleteBulletinManager?.showBulletin(above: self)
     }
 

--- a/Neuron/Services/WalletManager/WalletManager.swift
+++ b/Neuron/Services/WalletManager/WalletManager.swift
@@ -60,7 +60,7 @@ extension WalletManager {
 
         var privateKey = try bip32Keystore.UNSAFE_getPrivateKeyData(password: password, account: address)
         defer { Data.zero(&privateKey) }
-        guard let keystore = try EthereumKeystoreV3(privateKey: privateKey, password: password) else {
+        guard let keystore = try EthereumKeystoreV3(privateKey: privateKey, password: password, aesMode: "aes-128-ctr") else {
             throw Error.invalidMnemonic
         }
 
@@ -87,7 +87,7 @@ extension WalletManager {
 
     func importPrivateKey(privateKey: String, password: String) throws -> Wallet {
         guard let data = Data.fromHex(privateKey.trimmingCharacters(in: .whitespacesAndNewlines)),
-            let keystore = try EthereumKeystoreV3(privateKey: data, password: password),
+            let keystore = try EthereumKeystoreV3(privateKey: data, password: password, aesMode: "aes-128-ctr"),
             let address = keystore.getAddress()?.address else {
             throw Error.invalidPrivateKey
         }


### PR DESCRIPTION
## The (possible) reason Android wallet and MetaMask don't import

Web3swift uses `aes-128-cbc` mode as default. The above wallets don't seem to support this format.

## More info

`aes-128-cbc` is the default mode for Keystore v2 format. Since v3 `aes-128-ctr` is the minimal requirement; but a good wallet should support both.

## Solution

Just to make things simple, we'll change the default mode to `aes-128-ctr`.

## TODO

* See if it's possible to change default `scrypt` params to:
  * r: 8 (Web3swift default to 6)
  * p: 1
  * n: > 4096 (Web3swift default to 4096). A strong n would e as big as `262144` but that might be slow to generate thus need release mode benchmark.

## Update

Stop here without changing default `r`, `p` and `n`. Doing that would require forking and modifying `web3swift`. (In a long term sense, perhaps we should consider re-implement keystore core ourselves)